### PR TITLE
Add bla, cwd and gle support

### DIFF
--- a/src/lib/languages/bla.py
+++ b/src/lib/languages/bla.py
@@ -1,0 +1,21 @@
+"""
+Special processing functions for Siksika (Blackfoot) (bla) language.
+"""
+
+import re
+
+FST_FILES = {
+    'strict-analyzer': 'bla-analyser-gt-norm.hfstol',
+    'relaxed-analyzer': 'bla-analyser-gt-desc.hfstol',
+    'strict-generator': 'bla-generator-gt-norm.hfstol',
+}
+
+_PUNCTUATION = re.compile(r'[.,/#!$%\^&\*;:{}=_`~()]')
+
+
+def process_characters(text):
+    """Strip punctuation for BLA normalization."""
+    if not text or not isinstance(text, str):
+        return text
+
+    return _PUNCTUATION.sub('', text).strip()

--- a/src/lib/languages/ciw.py
+++ b/src/lib/languages/ciw.py
@@ -1,5 +1,5 @@
 """
-Special processing functions for Nishnaabemowin (Ojibwe) (ciw) language.
+Special processing functions for Anishnaabemowin (Ojibwe) (ciw) language.
 """
 
 import re

--- a/src/lib/languages/crgn.py
+++ b/src/lib/languages/crgn.py
@@ -1,5 +1,5 @@
 """
-Special processing functions for Cree (crgn) language.
+Special processing functions for Michif (Northern) (crgn) language.
 
 Note: Currently uses the same FST files as CRK since CRGN doesn't have
 its own FST files yet.

--- a/src/lib/languages/crk.py
+++ b/src/lib/languages/crk.py
@@ -1,5 +1,5 @@
 """
-Special processing functions for Plains Cree (crk) language.
+Special processing functions for Nêhiyawêwin (Plains Cree Y-dialect) (crk) language.
 """
 
 import re

--- a/src/lib/languages/cwd.py
+++ b/src/lib/languages/cwd.py
@@ -1,0 +1,21 @@
+"""
+Special processing functions for Nīhithawīwin (Woods Cree TH-dialect) (cwd) language.
+"""
+
+import re
+
+FST_FILES = {
+    'strict-analyzer': 'cwd-analyser-gt-norm.hfstol',
+    'relaxed-analyzer': 'cwd-analyser-gt-desc.hfstol',
+    'strict-generator': 'cwd-generator-gt-norm.hfstol',
+}
+
+_PUNCTUATION = re.compile(r'[.,/#!$%\^&\*;:{}=_`~()]')
+
+
+def process_characters(text):
+    """Strip punctuation for CWD normalization."""
+    if not text or not isinstance(text, str):
+        return text
+
+    return _PUNCTUATION.sub('', text).strip()

--- a/src/lib/languages/gle.py
+++ b/src/lib/languages/gle.py
@@ -1,0 +1,21 @@
+"""
+Special processing functions for Gaeilge (Irish) (gle) language.
+"""
+
+import re
+
+FST_FILES = {
+    'strict-analyzer': 'gle-analyser-gt-norm.hfstol',
+    'relaxed-analyzer': 'gle-analyser-gt-desc.hfstol',
+    'strict-generator': 'gle-generator-gt-norm.hfstol',
+}
+
+_PUNCTUATION = re.compile(r'[.,/#!$%\^&\*;:{}=_`~()]')
+
+
+def process_characters(text):
+    """Strip punctuation for GLE normalization."""
+    if not text or not isinstance(text, str):
+        return text
+
+    return _PUNCTUATION.sub('', text).strip()

--- a/src/lib/languages/otwc.py
+++ b/src/lib/languages/otwc.py
@@ -1,5 +1,5 @@
 """
-Special processing functions for Nishnaabemwin (Corbiere-style) (otwc) language.
+Special processing functions for Nishnaabemowin (Odawa - Corbiere) (otwc) language.
 """
 
 import re

--- a/src/lib/languages/otwr.py
+++ b/src/lib/languages/otwr.py
@@ -1,5 +1,5 @@
 """
-Special processing functions for Nishnaabemwin (Rhodes-style) (otwr) language.
+Special processing functions for Nishnaabemowin (Odawa - Rhodes) (otwr) language.
 """
 
 import re

--- a/src/lib/special_processing.py
+++ b/src/lib/special_processing.py
@@ -5,14 +5,17 @@ Provides a centralized registry for language-specific text processing functions.
 Each language defines its own special processing logic.
 """
 
-from lib.languages import crk, crgn, otwc, otwr, ciw
+from lib.languages import crk, crgn, otwc, otwr, ciw, bla, cwd, gle
 
 _languages = {
-    'crk': crk,
+    'bla': bla,
+    'ciw': ciw,
     'crgn': crgn,
+    'crk': crk,
+    'cwd': cwd,
+    'gle': gle,
     'otwc': otwc,
     'otwr': otwr,
-    'ciw': ciw,
 }
 
 

--- a/src/lib/transducers.py
+++ b/src/lib/transducers.py
@@ -2,14 +2,21 @@
 Transducer management and analysis functions.
 
 Handles loading and using FST transducers for word analysis.
-Transducers are loaded from EFS each time (not cached in memory)
-to avoid keeping large objects (hundreds of MB) in memory.
-The FST files themselves are cached on EFS after first download.
+Transducers are cached in module-level memory after first load so that warm
+Lambda invocations reuse already-loaded objects. Without caching, Python's GC
+does not promptly free the C-extension memory from TransducerFile objects, so
+each request would load a new copy before the previous one is released — causing
+memory to grow unboundedly across warm invocations.
+The FST files themselves are also cached on EFS after first S3 download.
 """
 
 from lib import fst as fst_module
 from lib import special_processing
 from lib.utils import prioritize_particles
+
+# Cache of loaded TransducerFile objects, keyed by (language_code, fst_type).
+# Persists across warm Lambda invocations.
+_transducer_cache: dict = {}
 
 
 def _extract_analyses(raw_results):
@@ -56,7 +63,7 @@ def _load_transducer_file(fst_path):
 
 
 def _get_transducer(language_code, fst_type):
-    """Load a transducer for the given language and FST type. Returns None if not available."""
+    """Load a transducer for the given language and FST type, using the cache. Returns None if not available."""
     processor = special_processing.get_language_processor(language_code)
     if not processor:
         raise ValueError(f'No language processor found for language: {language_code}')
@@ -65,22 +72,26 @@ def _get_transducer(language_code, fst_type):
     if not processor.FST_FILES.get(fst_type):
         return None
 
+    cache_key = (language_code, fst_type)
+    if cache_key in _transducer_cache:
+        return _transducer_cache[cache_key]
+
     file_name = processor.FST_FILES[fst_type]
     fst_path = fst_module.download_fst_from_s3(file_name)
-    return _load_transducer_file(fst_path)
+    transducer = _load_transducer_file(fst_path)
+    _transducer_cache[cache_key] = transducer
+    return transducer
 
 
 def get_strict_analyzer(language_code):
-    """Load strict analyzer for a language from EFS."""
+    """Load strict analyzer for a language, using the cache."""
     processor = special_processing.get_language_processor(language_code)
     if not processor:
         raise ValueError(f'No language processor found for language: {language_code}')
     if not hasattr(processor, 'FST_FILES') or not processor.FST_FILES.get('strict-analyzer'):
         raise ValueError(f'No strict-analyzer FST file defined for language: {language_code}')
 
-    file_name = processor.FST_FILES['strict-analyzer']
-    fst_path = fst_module.download_fst_from_s3(file_name)
-    return _load_transducer_file(fst_path)
+    return _get_transducer(language_code, 'strict-analyzer')
 
 
 def get_relaxed_analyzer(language_code):

--- a/src/test/integration/test_bulk_lookup.py
+++ b/src/test/integration/test_bulk_lookup.py
@@ -4,11 +4,14 @@ import pytest
 import requests
 
 LANGUAGES = [
-    ("crk", "êkwa"),
+    ("bla", "oki"),
+    ("ciw", "niin"),
     ("crgn", "êkwa"),
+    ("crk", "êkwa"),
+    ("cwd", "êkwa"),
+    ("gle", "agus"),
     ("otwc", "niin"),
     ("otwr", "niin"),
-    ("ciw", "niin"),
 ]
 
 

--- a/src/test/integration/test_suggest.py
+++ b/src/test/integration/test_suggest.py
@@ -4,11 +4,14 @@ import pytest
 import requests
 
 LANGUAGES = [
-    ("crk", "êkwa"),
+    ("bla", "oki"),
+    ("ciw", "niin"),
     ("crgn", "êkwa"),
+    ("crk", "êkwa"),
+    ("cwd", "êkwa"),
+    ("gle", "agus"),
     ("otwc", "niin"),
     ("otwr", "niin"),
-    ("ciw", "niin"),
 ]
 
 


### PR DESCRIPTION
Pulled and generated up to date transducers for lang-bla, lang-cwd and lang-gle

File names are the defaults for those repos except that they are prefix with the lang code for clarity.

A little extra work was done in this PR to better align our language naming between transcribe and the spellcheck API

Another pass at fixing the memory problem with the spellcheck lambda snuck into this one. Should be fixed properly now. As we add more languages a single warm lambda that has all the FSTs open in memory may need more than 3GB though. Hopefully at the point our AWS accounts will be 'old enough' that I can bump the limit on both staging and prod.

### Testing

Added and ran new integration tests