### PR TITLE
Add integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Use `--update` to re-upload existing files, `--verbose` for detailed output.
 API keys are managed manually so each service or user gets their own key. Use a descriptive `--name` that identifies the consumer.
 
 ```sh
-AWS_PROFILE=<your-profile> npm run create-api-key -- --name kiyanaw-backend --stage staging
+AWS_PROFILE=<your-profile> npm run create-api-key -- --name transcribe --stage staging
 ```
 
 The script creates the key, associates it with the usage plan, and prints the key value. Store the value securely — to revoke access, delete the key from **API Gateway > API Keys** in the AWS console.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "upload-fsts": "node scripts/upload-fst-files.js",
     "create-api-key": "node scripts/create-api-key.js",
     "test": "bash scripts/test.sh",
+    "test:integration:staging": "bash scripts/integration-test.sh --stage staging",
+    "test:integration:production": "bash scripts/integration-test.sh --stage production",
     "lint": "bash scripts/lint.sh"
   },
   "devDependencies": {

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    integration: marks tests as integration tests (deselect with '-m "not integration"')

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 pytest
 ruff
+requests

--- a/scripts/integration-test.sh
+++ b/scripts/integration-test.sh
@@ -27,9 +27,9 @@ if [[ -z "$STAGE" ]]; then
 fi
 
 if [[ "$STAGE" == "staging" ]]; then
-  BASE_URL="https://spellcheck.kiyanaw.dev"
+  BASE_URL="https://api.kiyanaw.dev/spellcheck"
 elif [[ "$STAGE" == "production" ]]; then
-  BASE_URL="https://spellcheck.kiyanaw.net"
+  BASE_URL="https://api.kiyanaw.net/spellcheck"
 else
   echo "Invalid stage: $STAGE. Must be 'staging' or 'production'." >&2
   exit 1
@@ -58,4 +58,4 @@ export SPELLCHECK_API_URL="$BASE_URL"
 export SPELLCHECK_API_KEY="$API_KEY"
 
 echo "Running integration tests against $BASE_URL..."
-python -m pytest src/test/integration/ -v
+python3 -m pytest src/test/integration/ -v

--- a/scripts/integration-test.sh
+++ b/scripts/integration-test.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+set -e
+
+STAGE=""
+PROFILE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --stage)
+      STAGE="$2"
+      shift 2
+      ;;
+    --profile)
+      PROFILE="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$STAGE" ]]; then
+  echo "Usage: $0 --stage staging|production [--profile <profile>]" >&2
+  exit 1
+fi
+
+if [[ "$STAGE" == "staging" ]]; then
+  BASE_URL="https://spellcheck.kiyanaw.dev"
+elif [[ "$STAGE" == "production" ]]; then
+  BASE_URL="https://spellcheck.kiyanaw.net"
+else
+  echo "Invalid stage: $STAGE. Must be 'staging' or 'production'." >&2
+  exit 1
+fi
+
+AWS_ARGS=()
+if [[ -n "$PROFILE" ]]; then
+  AWS_ARGS+=(--profile "$PROFILE")
+fi
+
+echo "Fetching API key for integration-test-${STAGE}..."
+API_KEY=$(aws apigateway get-api-keys \
+  --name-query "integration-test-${STAGE}" \
+  --include-values \
+  --query 'items[0].value' \
+  --output text \
+  "${AWS_ARGS[@]}")
+
+if [[ -z "$API_KEY" || "$API_KEY" == "None" ]]; then
+  echo "No API key found for 'integration-test-${STAGE}'." >&2
+  echo "Create one with: node scripts/create-api-key.js --name integration-test --stage ${STAGE} [--profile <profile>]" >&2
+  exit 1
+fi
+
+export SPELLCHECK_API_URL="$BASE_URL"
+export SPELLCHECK_API_KEY="$API_KEY"
+
+echo "Running integration tests against $BASE_URL..."
+python -m pytest src/test/integration/ -v

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -10,5 +10,5 @@ docker run --rm \
     python -m venv /opt/venv &&
     /opt/venv/bin/pip install hfst-altlab -r /requirements-dev.txt -q &&
     /opt/venv/bin/ruff check /var/task &&
-    PYTHONPATH=/var/task /opt/venv/bin/python -m pytest /var/task/test/ -v
+    PYTHONPATH=/var/task /opt/venv/bin/python -m pytest /var/task/test/ -v -m 'not integration'
   "

--- a/src/index.py
+++ b/src/index.py
@@ -54,7 +54,8 @@ def _check_unknowns(items, language_code):
 
     print('original_lookup:', original_lookup)
 
-    to_lookup = list(original_lookup.keys())
+    # Cap analyses to avoid OOM on languages with large relaxed FSTs (e.g. otwr)
+    to_lookup = list(original_lookup.keys())[:100]
     if to_lookup:
         suggested = transducers.generate_strict(to_lookup, language_code)
         print('suggested:', suggested)

--- a/src/test/integration/conftest.py
+++ b/src/test/integration/conftest.py
@@ -1,0 +1,32 @@
+"""Fixtures for integration tests."""
+
+import pytest
+
+
+def pytest_collection_modifyitems(items):
+    for item in items:
+        if "integration" in item.nodeid:
+            item.add_marker(pytest.mark.integration)
+
+
+@pytest.fixture(scope="session")
+def api_url(request):
+    import os
+    url = os.environ.get("SPELLCHECK_API_URL")
+    if not url:
+        pytest.skip("SPELLCHECK_API_URL not set")
+    return url.rstrip("/")
+
+
+@pytest.fixture(scope="session")
+def api_key(request):
+    import os
+    key = os.environ.get("SPELLCHECK_API_KEY")
+    if not key:
+        pytest.skip("SPELLCHECK_API_KEY not set")
+    return key
+
+
+@pytest.fixture(scope="session")
+def api_headers(api_key):
+    return {"x-api-key": api_key, "Content-Type": "application/json"}

--- a/src/test/integration/conftest.py
+++ b/src/test/integration/conftest.py
@@ -3,10 +3,8 @@
 import pytest
 
 
-def pytest_collection_modifyitems(items):
-    for item in items:
-        if "integration" in item.nodeid:
-            item.add_marker(pytest.mark.integration)
+def pytest_configure(config):
+    config.addinivalue_line("markers", "integration: marks tests as integration tests")
 
 
 @pytest.fixture(scope="session")

--- a/src/test/integration/test_bulk_lookup.py
+++ b/src/test/integration/test_bulk_lookup.py
@@ -1,4 +1,4 @@
-"""Integration tests for POST /spellcheck/bulk-lookup."""
+"""Integration tests for POST /bulk-lookup."""
 
 import pytest
 import requests
@@ -15,8 +15,8 @@ LANGUAGES = [
 @pytest.mark.parametrize("language_code,word", LANGUAGES)
 def test_bulk_lookup_returns_200(api_url, api_headers, language_code, word):
     resp = requests.post(
-        f"{api_url}/spellcheck/bulk-lookup",
-        json={"language_code": language_code, "words": [word]},
+        f"{api_url}/bulk-lookup",
+        json={"languageCode": language_code, "words": [word]},
         headers=api_headers,
         timeout=30,
     )
@@ -27,8 +27,8 @@ def test_bulk_lookup_returns_200(api_url, api_headers, language_code, word):
 @pytest.mark.parametrize("language_code,word", LANGUAGES)
 def test_bulk_lookup_response_structure(api_url, api_headers, language_code, word):
     resp = requests.post(
-        f"{api_url}/spellcheck/bulk-lookup",
-        json={"language_code": language_code, "words": [word]},
+        f"{api_url}/bulk-lookup",
+        json={"languageCode": language_code, "words": [word]},
         headers=api_headers,
         timeout=30,
     )
@@ -40,8 +40,8 @@ def test_bulk_lookup_response_structure(api_url, api_headers, language_code, wor
 
 def test_bulk_lookup_known_word_has_analyses(api_url, api_headers):
     resp = requests.post(
-        f"{api_url}/spellcheck/bulk-lookup",
-        json={"language_code": "crk", "words": ["êkwa"]},
+        f"{api_url}/bulk-lookup",
+        json={"languageCode": "crk", "words": ["êkwa"]},
         headers=api_headers,
         timeout=30,
     )
@@ -53,8 +53,8 @@ def test_bulk_lookup_known_word_has_analyses(api_url, api_headers):
 
 def test_bulk_lookup_unknown_word_has_suggestions(api_url, api_headers):
     resp = requests.post(
-        f"{api_url}/spellcheck/bulk-lookup",
-        json={"language_code": "crk", "words": ["ekwaa"]},
+        f"{api_url}/bulk-lookup",
+        json={"languageCode": "crk", "words": ["ekwaa"]},
         headers=api_headers,
         timeout=30,
     )
@@ -65,7 +65,7 @@ def test_bulk_lookup_unknown_word_has_suggestions(api_url, api_headers):
 
 def test_bulk_lookup_invalid_body_returns_400(api_url, api_headers):
     resp = requests.post(
-        f"{api_url}/spellcheck/bulk-lookup",
+        f"{api_url}/bulk-lookup",
         data="not json",
         headers={**api_headers, "Content-Type": "application/json"},
         timeout=30,
@@ -75,8 +75,8 @@ def test_bulk_lookup_invalid_body_returns_400(api_url, api_headers):
 
 def test_bulk_lookup_missing_fields_returns_400(api_url, api_headers):
     resp = requests.post(
-        f"{api_url}/spellcheck/bulk-lookup",
-        json={"language_code": "crk"},
+        f"{api_url}/bulk-lookup",
+        json={"languageCode": "crk"},
         headers=api_headers,
         timeout=30,
     )

--- a/src/test/integration/test_bulk_lookup.py
+++ b/src/test/integration/test_bulk_lookup.py
@@ -1,0 +1,83 @@
+"""Integration tests for POST /spellcheck/bulk-lookup."""
+
+import pytest
+import requests
+
+LANGUAGES = [
+    ("crk", "êkwa"),
+    ("crgn", "êkwa"),
+    ("otwc", "niin"),
+    ("otwr", "niin"),
+    ("ciw", "niin"),
+]
+
+
+@pytest.mark.parametrize("language_code,word", LANGUAGES)
+def test_bulk_lookup_returns_200(api_url, api_headers, language_code, word):
+    resp = requests.post(
+        f"{api_url}/spellcheck/bulk-lookup",
+        json={"language_code": language_code, "words": [word]},
+        headers=api_headers,
+        timeout=30,
+    )
+    assert resp.status_code == 200
+    assert isinstance(resp.json(), dict)
+
+
+@pytest.mark.parametrize("language_code,word", LANGUAGES)
+def test_bulk_lookup_response_structure(api_url, api_headers, language_code, word):
+    resp = requests.post(
+        f"{api_url}/spellcheck/bulk-lookup",
+        json={"language_code": language_code, "words": [word]},
+        headers=api_headers,
+        timeout=30,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert word in body
+    assert isinstance(body[word], list)
+
+
+def test_bulk_lookup_known_word_has_analyses(api_url, api_headers):
+    resp = requests.post(
+        f"{api_url}/spellcheck/bulk-lookup",
+        json={"language_code": "crk", "words": ["êkwa"]},
+        headers=api_headers,
+        timeout=30,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "êkwa" in body
+    assert len(body["êkwa"]) > 0
+
+
+def test_bulk_lookup_unknown_word_has_suggestions(api_url, api_headers):
+    resp = requests.post(
+        f"{api_url}/spellcheck/bulk-lookup",
+        json={"language_code": "crk", "words": ["ekwaa"]},
+        headers=api_headers,
+        timeout=30,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "_suggestions" in body
+
+
+def test_bulk_lookup_invalid_body_returns_400(api_url, api_headers):
+    resp = requests.post(
+        f"{api_url}/spellcheck/bulk-lookup",
+        data="not json",
+        headers={**api_headers, "Content-Type": "application/json"},
+        timeout=30,
+    )
+    assert resp.status_code == 400
+
+
+def test_bulk_lookup_missing_fields_returns_400(api_url, api_headers):
+    resp = requests.post(
+        f"{api_url}/spellcheck/bulk-lookup",
+        json={"language_code": "crk"},
+        headers=api_headers,
+        timeout=30,
+    )
+    assert resp.status_code == 400

--- a/src/test/integration/test_smoke.py
+++ b/src/test/integration/test_smoke.py
@@ -5,8 +5,8 @@ import requests
 
 def test_api_is_reachable(api_url, api_headers):
     resp = requests.post(
-        f"{api_url}/spellcheck/bulk-lookup",
-        json={"language_code": "crk", "words": ["êkwa"]},
+        f"{api_url}/bulk-lookup",
+        json={"languageCode": "crk", "words": ["êkwa"]},
         headers=api_headers,
         timeout=30,
     )
@@ -15,8 +15,8 @@ def test_api_is_reachable(api_url, api_headers):
 
 def test_api_requires_auth(api_url):
     resp = requests.post(
-        f"{api_url}/spellcheck/bulk-lookup",
-        json={"language_code": "crk", "words": ["êkwa"]},
+        f"{api_url}/bulk-lookup",
+        json={"languageCode": "crk", "words": ["êkwa"]},
         headers={"Content-Type": "application/json"},
         timeout=30,
     )

--- a/src/test/integration/test_smoke.py
+++ b/src/test/integration/test_smoke.py
@@ -1,0 +1,23 @@
+"""Smoke tests — reachability and auth."""
+
+import requests
+
+
+def test_api_is_reachable(api_url, api_headers):
+    resp = requests.post(
+        f"{api_url}/spellcheck/bulk-lookup",
+        json={"language_code": "crk", "words": ["êkwa"]},
+        headers=api_headers,
+        timeout=30,
+    )
+    assert resp.status_code == 200
+
+
+def test_api_requires_auth(api_url):
+    resp = requests.post(
+        f"{api_url}/spellcheck/bulk-lookup",
+        json={"language_code": "crk", "words": ["êkwa"]},
+        headers={"Content-Type": "application/json"},
+        timeout=30,
+    )
+    assert resp.status_code == 403

--- a/src/test/integration/test_suggest.py
+++ b/src/test/integration/test_suggest.py
@@ -1,0 +1,69 @@
+"""Integration tests for POST /spellcheck/suggest."""
+
+import pytest
+import requests
+
+LANGUAGES = [
+    ("crk", "êkwa"),
+    ("crgn", "êkwa"),
+    ("otwc", "niin"),
+    ("otwr", "niin"),
+    ("ciw", "niin"),
+]
+
+
+@pytest.mark.parametrize("language_code,word", LANGUAGES)
+def test_suggest_returns_200(api_url, api_headers, language_code, word):
+    resp = requests.post(
+        f"{api_url}/spellcheck/suggest",
+        json={"language_code": language_code, "words": [word]},
+        headers=api_headers,
+        timeout=30,
+    )
+    assert resp.status_code == 200
+    assert isinstance(resp.json(), dict)
+
+
+@pytest.mark.parametrize("language_code,word", LANGUAGES)
+def test_suggest_response_values_are_lists(api_url, api_headers, language_code, word):
+    resp = requests.post(
+        f"{api_url}/spellcheck/suggest",
+        json={"language_code": language_code, "words": [word]},
+        headers=api_headers,
+        timeout=30,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    for value in body.values():
+        assert isinstance(value, list)
+        assert all(isinstance(item, str) for item in value)
+
+
+def test_suggest_invalid_body_returns_400(api_url, api_headers):
+    resp = requests.post(
+        f"{api_url}/spellcheck/suggest",
+        data="not json",
+        headers={**api_headers, "Content-Type": "application/json"},
+        timeout=30,
+    )
+    assert resp.status_code == 400
+
+
+def test_suggest_missing_language_code_returns_400(api_url, api_headers):
+    resp = requests.post(
+        f"{api_url}/spellcheck/suggest",
+        json={"words": ["êkwa"]},
+        headers=api_headers,
+        timeout=30,
+    )
+    assert resp.status_code == 400
+
+
+def test_suggest_missing_words_returns_400(api_url, api_headers):
+    resp = requests.post(
+        f"{api_url}/spellcheck/suggest",
+        json={"language_code": "crk"},
+        headers=api_headers,
+        timeout=30,
+    )
+    assert resp.status_code == 400

--- a/src/test/integration/test_suggest.py
+++ b/src/test/integration/test_suggest.py
@@ -1,4 +1,4 @@
-"""Integration tests for POST /spellcheck/suggest."""
+"""Integration tests for POST /suggest."""
 
 import pytest
 import requests
@@ -15,8 +15,8 @@ LANGUAGES = [
 @pytest.mark.parametrize("language_code,word", LANGUAGES)
 def test_suggest_returns_200(api_url, api_headers, language_code, word):
     resp = requests.post(
-        f"{api_url}/spellcheck/suggest",
-        json={"language_code": language_code, "words": [word]},
+        f"{api_url}/suggest",
+        json={"languageCode": language_code, "words": [word]},
         headers=api_headers,
         timeout=30,
     )
@@ -27,8 +27,8 @@ def test_suggest_returns_200(api_url, api_headers, language_code, word):
 @pytest.mark.parametrize("language_code,word", LANGUAGES)
 def test_suggest_response_values_are_lists(api_url, api_headers, language_code, word):
     resp = requests.post(
-        f"{api_url}/spellcheck/suggest",
-        json={"language_code": language_code, "words": [word]},
+        f"{api_url}/suggest",
+        json={"languageCode": language_code, "words": [word]},
         headers=api_headers,
         timeout=30,
     )
@@ -41,7 +41,7 @@ def test_suggest_response_values_are_lists(api_url, api_headers, language_code, 
 
 def test_suggest_invalid_body_returns_400(api_url, api_headers):
     resp = requests.post(
-        f"{api_url}/spellcheck/suggest",
+        f"{api_url}/suggest",
         data="not json",
         headers={**api_headers, "Content-Type": "application/json"},
         timeout=30,
@@ -51,7 +51,7 @@ def test_suggest_invalid_body_returns_400(api_url, api_headers):
 
 def test_suggest_missing_language_code_returns_400(api_url, api_headers):
     resp = requests.post(
-        f"{api_url}/spellcheck/suggest",
+        f"{api_url}/suggest",
         json={"words": ["êkwa"]},
         headers=api_headers,
         timeout=30,
@@ -61,8 +61,8 @@ def test_suggest_missing_language_code_returns_400(api_url, api_headers):
 
 def test_suggest_missing_words_returns_400(api_url, api_headers):
     resp = requests.post(
-        f"{api_url}/spellcheck/suggest",
-        json={"language_code": "crk"},
+        f"{api_url}/suggest",
+        json={"languageCode": "crk"},
         headers=api_headers,
         timeout=30,
     )


### PR DESCRIPTION
Got tired of using postman to verify the api deploys. Added integration test commands for both staging and production. They have their own API keys, which have already been provisioned.

Ended up fixing a OOM error when you hit suggest with a very common word and the FSTs are large.

### Tests

Run them successfully against both staging and production

<img width="1847" height="922" alt="Screenshot 2026-03-23 050548" src="https://github.com/user-attachments/assets/eb3060c1-f8b6-4514-949b-36f356aeec73" />
